### PR TITLE
Add codebuild and ecs cfn templates

### DIFF
--- a/codebuild-ecs.template.yaml
+++ b/codebuild-ecs.template.yaml
@@ -1,0 +1,192 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: CodeBuild projects and ECR repositories for ITS DataHub microservices.
+
+Parameters: 
+  ClusterNameDev: 
+    Type: String
+    Default: "datahub-cluster-dev"
+  ClusterNameStage: 
+    Type: String
+    Default: "datahub-cluster-stage"
+  ClusterNameProd: 
+    Type: String
+    Default: "datahub-cluster-prod"
+
+
+Resources:
+ ######################
+  ### Admin UI Resources
+
+  # ECR Repositories
+  AdminUIDev:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: admin-ui-dev
+  AdminUIStage:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: admin-ui-stage
+  AdminUIProd:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: admin-ui-prod
+
+  # CodeBuild Projects
+  AdminUICodeBuildGeneric:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Description: CodeBuild project for testing buildability of all commits.
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/standard:3.0
+        Type: LINUX_CONTAINER
+        PrivilegedMode: True
+        EnvironmentVariables:
+          - Name: AWS_ACCOUNT_ID
+            Type: PLAINTEXT
+            Value: "null"
+          - Name: IMAGE_REPO_NAME
+            Type: PLAINTEXT
+            Value: "null"
+      Name: admin-ui-generic
+      ServiceRole: "{{resolve:ssm:codebuild-role-arn:1}}"
+      Source:
+        Auth:
+          Type: OAUTH
+        Location: https://github.com/usdot-its-jpo-data-portal/datahub-admin-ui.git
+        Type: GITHUB
+      Triggers:
+        FilterGroups:
+          - - Type: EVENT
+              Pattern: PUSH
+            - Type: HEAD_REF
+              Pattern: "^refs/heads/(master|development)$"
+              ExcludeMatchedPattern: True
+        Webhook: True
+
+  AdminUICodeBuildDev:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Description: CodeBuild project for deploying the Admin UI service to dev.
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/standard:3.0
+        Type: LINUX_CONTAINER
+        PrivilegedMode: True
+        EnvironmentVariables:
+          - Name: AWS_ACCOUNT_ID
+            Value: !Ref AWS::AccountId
+            Type: PLAINTEXT
+          - Name: IMAGE_REPO_NAME
+            Value: !Ref AdminUIDev
+            Type: PLAINTEXT
+          - Name: ECS_CLUSTER
+            Value: !Ref ClusterNameDev # TODO replace this with import
+            Type: PLAINTEXT
+          - Name: ECS_SERVICE
+            Value: "admin-ui-dev" # TODO replace this with import
+            Type: PLAINTEXT
+      Name: admin-ui-dev
+      ServiceRole: "{{resolve:ssm:codebuild-role-arn:1}}"
+      Source:
+        Auth:
+          Type: OAUTH
+        Location: https://github.com/usdot-its-jpo-data-portal/datahub-admin-ui.git
+        Type: GITHUB
+      Triggers:
+        FilterGroups:
+          - - Type: EVENT
+              Pattern: PUSH
+            - Type: HEAD_REF
+              Pattern: "^refs/heads/development$"
+              ExcludeMatchedPattern: False
+        Webhook: True
+
+  AdminUICodeBuildStage:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Description: CodeBuild project for deploying the Admin UI service to stage.
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/standard:3.0
+        Type: LINUX_CONTAINER
+        PrivilegedMode: True
+        EnvironmentVariables:
+          - Name: AWS_ACCOUNT_ID
+            Value: !Ref AWS::AccountId
+            Type: PLAINTEXT
+          - Name: IMAGE_REPO_NAME
+            Value: !Ref AdminUIStage
+            Type: PLAINTEXT
+          - Name: ECS_CLUSTER
+            Value: !Ref ClusterNameStage # TODO replace this with import
+            Type: PLAINTEXT
+          - Name: ECS_SERVICE
+            Value: "admin-ui-stage" # TODO replace this with import
+            Type: PLAINTEXT
+      Name: admin-ui-stage
+      ServiceRole: "{{resolve:ssm:codebuild-role-arn:1}}"
+      Source:
+        Auth:
+          Type: OAUTH
+        Location: https://github.com/usdot-its-jpo-data-portal/datahub-admin-ui.git
+        Type: GITHUB
+      Triggers:
+        FilterGroups:
+          - - Type: EVENT
+              Pattern: PUSH
+            - Type: HEAD_REF
+              Pattern: "^refs/heads/master$"
+              ExcludeMatchedPattern: False
+        Webhook: True
+
+  AdminUICodeBuildProd:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Description: CodeBuild project for promoting the Admin UI service from stage to prod.
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/standard:3.0
+        Type: LINUX_CONTAINER
+        PrivilegedMode: True
+        EnvironmentVariables:
+          - Name: STAGE_REPO_NAME
+            Value: !Ref AdminUIStage
+            Type: PLAINTEXT
+          - Name: PROD_REPO_NAME
+            Value: !Ref AdminUIProd
+            Type: PLAINTEXT
+          - Name: AWS_ACCOUNT_ID
+            Value: !Ref AWS::AccountId
+            Type: PLAINTEXT
+          - Name: $CLUSTER_NAME
+            Value: !Ref ClusterNameProd
+            Type: PLAINTEXT
+          - Name: SERVICE_NAME
+            Value: "admin-ui-prod-service" # TODO replace with import
+            Type: PLAINTEXT
+      Name: admin-ui-prod-promotion
+      ServiceRole: "{{resolve:ssm:codebuild-role-arn:1}}"
+      Source:
+        Type: NO_SOURCE
+        BuildSpec: |
+          version: 0.2
+          phases:
+            install:
+              runtime-versions:
+                docker: 18
+            build:
+              commands:
+                - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+                - docker pull $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/$STAGE_REPO_NAME:latest
+                - docker tag $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/$STAGE_REPO_NAME:latest $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/$PROD_REPO_NAME:latest
+                - docker push $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/$PROD_REPO_NAME:latest
+                - aws ecs update-service --cluster $CLUSTER_NAME --service $SERVICE_NAME --force-new-deployment

--- a/codebuild-lambdas.template.yaml
+++ b/codebuild-lambdas.template.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: CodeBuild projects and ECR repositories for ITS DataHub.
+Description: CodeBuild projects and ECR repositories for ITS DataHub lambda functions.
 
 ### Required SSM Variables:
 # "{{resolve:ssm:base-image:version}}"

--- a/create-stack.sh
+++ b/create-stack.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-aws cloudformation create-stack --stack-name datahub-lambda-codebuild-ecr --template-body file://codebuild.template.yml

--- a/ecs.template.yaml
+++ b/ecs.template.yaml
@@ -1,0 +1,616 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: ECS services used by ITS DataHub.
+
+### Required SSM Variables:
+# "{{resolve:ssm:ecs-task-role-arn:version}}"
+# "{{resolve:ssm:ecs-execution-role-arn:version}}"
+# "{{resolve:ssm:vpc-id:version}}"
+# "{{resolve:ssm:external-sg-id:version}}"
+# "{{resolve:ssm:vpc-sg-id:version}}"
+# "{{resolve:ssm:ecs-sg-id:version}}"
+# "{{resolve:ssm:subnet-a-dev-id:version}}"
+# "{{resolve:ssm:subnet-b-dev-id:version}}"
+# "{{resolve:ssm:subnet-a-stage-id:version}}"
+# "{{resolve:ssm:subnet-b-stage-id:version}}"
+# "{{resolve:ssm:subnet-a-prod-id:version}}"
+# "{{resolve:ssm:subnet-b-prod-id:version}}"
+# "{{resolve:ssm:admin-api-token:version}}"
+# "{{resolve:ssm:es-domain-dev:version}}"
+
+Parameters:
+  AdminUIPort:
+    Type: Number
+    Default: 80
+  AdminAPIPort:
+    Type: Number
+    Default: 3000
+
+Resources:
+  ###################################
+  ### Admin UI Resources
+
+  # Dev
+  AdminUIServiceDev:
+    Type: AWS::ECS::Service
+    DependsOn:
+      - AdminUIListenerDev
+    Properties:
+      ServiceName: admin-ui-service-dev
+      Cluster: datahub-cluster-dev # TODO replace with ImportValue
+      TaskDefinition: !Ref AdminUITaskDefDev
+      DeploymentConfiguration:
+        MinimumHealthyPercent: 100
+        MaximumPercent: 200
+      DesiredCount: 0 # TODO replace with 1 when codebuild deployments are successful
+      HealthCheckGracePeriodSeconds: 60
+      LaunchType: FARGATE
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          Subnets:
+            - "{{resolve:ssm:subnet-a-dev-id:1}}"
+            - "{{resolve:ssm:subnet-b-dev-id:1}}"
+          SecurityGroups:
+            - "{{resolve:ssm:ecs-sg-id:1}}"
+      LoadBalancers:
+        - ContainerName: admin-ui-container-dev
+          ContainerPort: !Ref AdminUIPort
+          TargetGroupArn: !Ref AdminUITargetGroupDev
+
+  AdminUITargetGroupDev:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckPath: "/"
+      Name: admin-ui-dev-tg
+      Port: !Ref AdminUIPort
+      Protocol: HTTP
+      TargetType: ip
+      VpcId: "{{resolve:ssm:vpc-id:1}}"
+
+  AdminUIListenerDev:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - TargetGroupArn: !Ref AdminUITargetGroupDev
+          Type: forward
+      LoadBalancerArn: !Ref AdminUILoadBalancerDev
+      Port: !Ref AdminUIPort
+      Protocol: HTTP
+
+  AdminUILoadBalancerDev:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: admin-ui-dev-lb
+      Scheme: internal
+      SecurityGroups:
+        - "{{resolve:ssm:vpc-sg-id:1}}"
+      Subnets:
+        - "{{resolve:ssm:subnet-a-dev-id:1}}"
+        - "{{resolve:ssm:subnet-b-dev-id:1}}"
+
+  AdminUITaskDefDev:
+    Type: AWS::ECS::TaskDefinition
+    DependsOn:
+      - AdminUILogGroupDev
+    Properties:
+      Family: admin-ui-dev-taskdef
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      Cpu: 256
+      Memory: 0.5GB
+      ExecutionRoleArn: "{{resolve:ssm:ecs-execution-role-arn:1}}"
+      TaskRoleArn: "{{resolve:ssm:ecs-task-role-arn:1}}"
+      ContainerDefinitions:
+        - Name: admin-ui-container-dev
+          Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/admin-ui-dev:latest"
+          PortMappings:
+            - ContainerPort: !Ref AdminUIPort
+          Environment:
+            - Name: PROXY_PASS
+              Value: !Sub
+                - "resolver 10.209.97.136 valid=10s; set $backend \"http://${LB_DOMAIN}:3000\"; proxy_pass $backend;"
+                - { LB_DOMAIN: !GetAtt AdminUILoadBalancerDev.DNSName }
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref AWS::Region
+              awslogs-group: !Ref AdminUILogGroupDev
+              awslogs-stream-prefix: ecs
+
+  AdminUILogGroupDev:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: "/ecs/admin-ui-dev-taskdef"
+
+  # Stage
+  AdminUIServiceStage:
+    Type: AWS::ECS::Service
+    DependsOn:
+      - AdminUIListenerStage
+    Properties:
+      ServiceName: admin-ui-service-stage
+      Cluster: datahub-cluster-stage # TODO replace with ImportValue
+      TaskDefinition: !Ref AdminUITaskDefStage
+      DeploymentConfiguration:
+        MinimumHealthyPercent: 100
+        MaximumPercent: 200
+      DesiredCount: 0 # TODO replace with 1 when codebuild deployments are successful
+      HealthCheckGracePeriodSeconds: 60
+      LaunchType: FARGATE
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          Subnets:
+            - "{{resolve:ssm:subnet-a-stage-id:1}}"
+            - "{{resolve:ssm:subnet-b-stage-id:1}}"
+          SecurityGroups:
+            - "{{resolve:ssm:ecs-sg-id:1}}"
+      LoadBalancers:
+        - ContainerName: admin-ui-container-stage
+          ContainerPort: !Ref AdminUIPort
+          TargetGroupArn: !Ref AdminUITargetGroupStage
+
+  AdminUITargetGroupStage:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckPath: "/"
+      Name: admin-ui-stage-tg
+      Port: !Ref AdminUIPort
+      Protocol: HTTP
+      TargetType: ip
+      VpcId: "{{resolve:ssm:vpc-id:1}}"
+
+  AdminUIListenerStage:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - TargetGroupArn: !Ref AdminUITargetGroupStage
+          Type: forward
+      LoadBalancerArn: !Ref AdminUILoadBalancerStage
+      Port: !Ref AdminUIPort
+      Protocol: HTTP
+
+  AdminUILoadBalancerStage:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: admin-ui-stage-lb
+      Scheme: internal
+      SecurityGroups:
+        - "{{resolve:ssm:vpc-sg-id:1}}"
+      Subnets:
+        - "{{resolve:ssm:subnet-a-stage-id:1}}"
+        - "{{resolve:ssm:subnet-b-stage-id:1}}"
+
+  AdminUITaskDefStage:
+    Type: AWS::ECS::TaskDefinition
+    DependsOn:
+      - AdminUILogGroupStage
+    Properties:
+      Family: admin-ui-stage-taskdef
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      Cpu: 256
+      Memory: 0.5GB
+      ExecutionRoleArn: "{{resolve:ssm:ecs-execution-role-arn:1}}"
+      TaskRoleArn: "{{resolve:ssm:ecs-task-role-arn:1}}"
+      ContainerDefinitions:
+        - Name: admin-ui-container-stage
+          Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/admin-ui-stage:latest"
+          PortMappings:
+            - ContainerPort: !Ref AdminUIPort
+          Environment:
+            - Name: PROXY_PASS
+              Value: !Sub
+                - "resolver 10.209.97.136 valid=10s; set $backend \"http://${LB_DOMAIN}:3000\"; proxy_pass $backend;"
+                - { LB_DOMAIN: !GetAtt AdminUILoadBalancerStage.DNSName }
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref AWS::Region
+              awslogs-group: !Ref AdminUILogGroupStage
+              awslogs-stream-prefix: ecs
+
+  AdminUILogGroupStage:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: "/ecs/admin-ui-stage-taskdef"
+
+  # Prod
+  AdminUIServiceProd:
+    Type: AWS::ECS::Service
+    DependsOn:
+      - AdminUIListenerProd
+    Properties:
+      ServiceName: admin-ui-service-prod
+      Cluster: datahub-cluster-prod # TODO replace with ImportValue
+      TaskDefinition: !Ref AdminUITaskDefProd
+      DeploymentConfiguration:
+        MinimumHealthyPercent: 100
+        MaximumPercent: 200
+      DesiredCount: 0 # TODO replace with 1 when codebuild deployments are successful
+      HealthCheckGracePeriodSeconds: 60
+      LaunchType: FARGATE
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          Subnets:
+            - "{{resolve:ssm:subnet-a-prod-id:1}}"
+            - "{{resolve:ssm:subnet-b-prod-id:1}}"
+          SecurityGroups:
+            - "{{resolve:ssm:ecs-sg-id:1}}"
+      LoadBalancers:
+        - ContainerName: admin-ui-container-prod
+          ContainerPort: !Ref AdminUIPort
+          TargetGroupArn: !Ref AdminUITargetGroupProd
+
+  AdminUITargetGroupProd:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckPath: "/"
+      Name: admin-ui-prod-tg
+      Port: !Ref AdminUIPort
+      Protocol: HTTP
+      TargetType: ip
+      VpcId: "{{resolve:ssm:vpc-id:1}}"
+
+  AdminUIListenerProd:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - TargetGroupArn: !Ref AdminUITargetGroupProd
+          Type: forward
+      LoadBalancerArn: !Ref AdminUILoadBalancerProd
+      Port: !Ref AdminUIPort
+      Protocol: HTTP
+
+  AdminUILoadBalancerProd:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: admin-ui-prod-lb
+      Scheme: internal
+      SecurityGroups:
+        - "{{resolve:ssm:vpc-sg-id:1}}"
+      Subnets:
+        - "{{resolve:ssm:subnet-a-prod-id:1}}"
+        - "{{resolve:ssm:subnet-b-prod-id:1}}"
+
+  AdminUITaskDefProd:
+    Type: AWS::ECS::TaskDefinition
+    DependsOn:
+      - AdminUILogGroupProd
+    Properties:
+      Family: admin-ui-prod-taskdef
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      Cpu: 256
+      Memory: 0.5GB
+      ExecutionRoleArn: "{{resolve:ssm:ecs-execution-role-arn:1}}"
+      TaskRoleArn: "{{resolve:ssm:ecs-task-role-arn:1}}"
+      ContainerDefinitions:
+        - Name: admin-ui-container-prod
+          Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/admin-ui-prod:latest"
+          PortMappings:
+            - ContainerPort: !Ref AdminUIPort
+          Environment:
+            - Name: PROXY_PASS
+              Value: !Sub
+                - "resolver 10.209.97.136 valid=10s; set $backend \"http://${LB_DOMAIN}:3000\"; proxy_pass $backend;"
+                - { LB_DOMAIN: !GetAtt AdminUILoadBalancerProd.DNSName }
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref AWS::Region
+              awslogs-group: !Ref AdminUILogGroupProd
+              awslogs-stream-prefix: ecs
+
+  AdminUILogGroupProd:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: "/ecs/admin-ui-prod-taskdef"
+
+  ###################################
+  ### Admin API Resources
+
+  # Dev
+  AdminAPIServiceDev:
+    Type: AWS::ECS::Service
+    DependsOn:
+      - AdminAPIListenerDev
+    Properties:
+      ServiceName: admin-api-service-dev
+      Cluster: datahub-cluster-dev # TODO replace with ImportValue
+      TaskDefinition: !Ref AdminAPITaskDefDev
+      DeploymentConfiguration:
+        MinimumHealthyPercent: 100
+        MaximumPercent: 200
+      DesiredCount: 0 # TODO replace with 1 when codebuild deployments are successful
+      HealthCheckGracePeriodSeconds: 60
+      LaunchType: FARGATE
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          Subnets:
+            - "{{resolve:ssm:subnet-a-dev-id:1}}"
+            - "{{resolve:ssm:subnet-b-dev-id:1}}"
+          SecurityGroups:
+            - "{{resolve:ssm:ecs-sg-id:1}}"
+      LoadBalancers:
+        - ContainerName: admin-api-container-dev
+          ContainerPort: !Ref AdminAPIPort
+          TargetGroupArn: !Ref AdminAPITargetGroupDev
+
+  AdminAPITargetGroupDev:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckPath: "/"
+      Name: admin-api-dev-tg
+      Port: !Ref AdminAPIPort
+      Protocol: HTTP
+      TargetType: ip
+      VpcId: "{{resolve:ssm:vpc-id:1}}"
+
+  AdminAPIListenerDev:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - TargetGroupArn: !Ref AdminAPITargetGroupDev
+          Type: forward
+      LoadBalancerArn: !Ref AdminAPILoadBalancerDev
+      Port: !Ref AdminAPIPort
+      Protocol: HTTP
+
+  AdminAPILoadBalancerDev:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: admin-api-dev-lb
+      Scheme: internal
+      SecurityGroups:
+        - "{{resolve:ssm:vpc-sg-id:1}}"
+      Subnets:
+        - "{{resolve:ssm:subnet-a-dev-id:1}}"
+        - "{{resolve:ssm:subnet-b-dev-id:1}}"
+
+  AdminAPITaskDefDev:
+    Type: AWS::ECS::TaskDefinition
+    DependsOn:
+      - AdminAPILogGroupDev
+    Properties:
+      Family: admin-api-dev-taskdef
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      Cpu: 256
+      Memory: 0.5GB
+      ExecutionRoleArn: "{{resolve:ssm:ecs-execution-role-arn:1}}"
+      TaskRoleArn: "{{resolve:ssm:ecs-task-role-arn:1}}"
+      ContainerDefinitions:
+        - Name: admin-api-container-dev
+          Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/admin-api-dev:latest"
+          PortMappings:
+            - ContainerPort: !Ref AdminAPIPort
+          Environment:
+            - Name: datahub.admin.api.token.key
+              Value: "{{resolve:ssm:admin-api-token:1}}"
+            - Name: datahub.admin.api.es.host
+              Value: "{{resolve:ssm:es-domain-dev:1}}"
+            - Name: datahub.admin.api.es.port
+              Value: "443"
+            - Name: datahub.admin.api.es.scheme
+              Value: "https"
+            - Name: JAVA_OPTS
+              Value: "-Xmx512M -Xms512M"
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref AWS::Region
+              awslogs-group: !Ref AdminAPILogGroupDev
+              awslogs-stream-prefix: ecs
+
+  AdminAPILogGroupDev:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: "/ecs/admin-api-dev-taskdef"
+
+  # Stage
+  AdminAPIServiceStage:
+    Type: AWS::ECS::Service
+    DependsOn:
+      - AdminAPIListenerStage
+    Properties:
+      ServiceName: admin-api-service-stage
+      Cluster: datahub-cluster-stage # TODO replace with ImportValue
+      TaskDefinition: !Ref AdminAPITaskDefStage
+      DeploymentConfiguration:
+        MinimumHealthyPercent: 100
+        MaximumPercent: 200
+      DesiredCount: 0 # TODO replace with 1 when codebuild deployments are successful
+      HealthCheckGracePeriodSeconds: 60
+      LaunchType: FARGATE
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          Subnets:
+            - "{{resolve:ssm:subnet-a-stage-id:1}}"
+            - "{{resolve:ssm:subnet-b-stage-id:1}}"
+          SecurityGroups:
+            - "{{resolve:ssm:ecs-sg-id:1}}"
+      LoadBalancers:
+        - ContainerName: admin-api-container-stage
+          ContainerPort: !Ref AdminAPIPort
+          TargetGroupArn: !Ref AdminAPITargetGroupStage
+
+  AdminAPITargetGroupStage:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckPath: "/"
+      Name: admin-api-stage-tg
+      Port: !Ref AdminAPIPort
+      Protocol: HTTP
+      TargetType: ip
+      VpcId: "{{resolve:ssm:vpc-id:1}}"
+
+  AdminAPIListenerStage:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - TargetGroupArn: !Ref AdminAPITargetGroupStage
+          Type: forward
+      LoadBalancerArn: !Ref AdminAPILoadBalancerStage
+      Port: !Ref AdminAPIPort
+      Protocol: HTTP
+
+  AdminAPILoadBalancerStage:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: admin-api-stage-lb
+      Scheme: internal
+      SecurityGroups:
+        - "{{resolve:ssm:vpc-sg-id:1}}"
+      Subnets:
+        - "{{resolve:ssm:subnet-a-stage-id:1}}"
+        - "{{resolve:ssm:subnet-b-stage-id:1}}"
+
+  AdminAPITaskDefStage:
+    Type: AWS::ECS::TaskDefinition
+    DependsOn:
+      - AdminAPILogGroupStage
+    Properties:
+      Family: admin-api-stage-taskdef
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      Cpu: 256
+      Memory: 0.5GB
+      ExecutionRoleArn: "{{resolve:ssm:ecs-execution-role-arn:1}}"
+      TaskRoleArn: "{{resolve:ssm:ecs-task-role-arn:1}}"
+      ContainerDefinitions:
+        - Name: admin-api-container-stage
+          Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/admin-api-stage:latest"
+          PortMappings:
+            - ContainerPort: !Ref AdminAPIPort
+          Environment:
+            - Name: datahub.admin.api.token.key
+              Value: "{{resolve:ssm:admin-api-token:1}}"
+            - Name: datahub.admin.api.es.host
+              Value: "{{resolve:ssm:es-domain-stage:1}}"
+            - Name: datahub.admin.api.es.port
+              Value: "443"
+            - Name: datahub.admin.api.es.scheme
+              Value: "https"
+            - Name: JAVA_OPTS
+              Value: "-Xmx512M -Xms512M"
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref AWS::Region
+              awslogs-group: !Ref AdminAPILogGroupStage
+              awslogs-stream-prefix: ecs
+
+  AdminAPILogGroupStage:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: "/ecs/admin-api-stage-taskdef"
+
+  # Prod
+  AdminAPIServiceProd:
+    Type: AWS::ECS::Service
+    DependsOn:
+      - AdminAPIListenerProd
+    Properties:
+      ServiceName: admin-api-service-prod
+      Cluster: datahub-cluster-prod # TODO replace with ImportValue
+      TaskDefinition: !Ref AdminAPITaskDefProd
+      DeploymentConfiguration:
+        MinimumHealthyPercent: 100
+        MaximumPercent: 200
+      DesiredCount: 0 # TODO replace with 1 when codebuild deployments are successful
+      HealthCheckGracePeriodSeconds: 60
+      LaunchType: FARGATE
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          Subnets:
+            - "{{resolve:ssm:subnet-a-prod-id:1}}"
+            - "{{resolve:ssm:subnet-b-prod-id:1}}"
+          SecurityGroups:
+            - "{{resolve:ssm:ecs-sg-id:1}}"
+      LoadBalancers:
+        - ContainerName: admin-api-container-prod
+          ContainerPort: !Ref AdminAPIPort
+          TargetGroupArn: !Ref AdminAPITargetGroupProd
+
+  AdminAPITargetGroupProd:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckPath: "/"
+      Name: admin-api-prod-tg
+      Port: !Ref AdminAPIPort
+      Protocol: HTTP
+      TargetType: ip
+      VpcId: "{{resolve:ssm:vpc-id:1}}"
+
+  AdminAPIListenerProd:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - TargetGroupArn: !Ref AdminAPITargetGroupProd
+          Type: forward
+      LoadBalancerArn: !Ref AdminAPILoadBalancerProd
+      Port: !Ref AdminAPIPort
+      Protocol: HTTP
+
+  AdminAPILoadBalancerProd:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: admin-api-prod-lb
+      Scheme: internal
+      SecurityGroups:
+        - "{{resolve:ssm:vpc-sg-id:1}}"
+      Subnets:
+        - "{{resolve:ssm:subnet-a-prod-id:1}}"
+        - "{{resolve:ssm:subnet-b-prod-id:1}}"
+
+  AdminAPITaskDefProd:
+    Type: AWS::ECS::TaskDefinition
+    DependsOn:
+      - AdminAPILogGroupProd
+    Properties:
+      Family: admin-api-prod-taskdef
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      Cpu: 256
+      Memory: 0.5GB
+      ExecutionRoleArn: "{{resolve:ssm:ecs-execution-role-arn:1}}"
+      TaskRoleArn: "{{resolve:ssm:ecs-task-role-arn:1}}"
+      ContainerDefinitions:
+        - Name: admin-api-container-prod
+          Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/admin-api-prod:latest"
+          PortMappings:
+            - ContainerPort: !Ref AdminAPIPort
+          Environment:
+            - Name: datahub.admin.api.token.key
+              Value: "{{resolve:ssm:admin-api-token:1}}"
+            - Name: datahub.admin.api.es.host
+              Value: "{{resolve:ssm:es-domain-prod:1}}"
+            - Name: datahub.admin.api.es.port
+              Value: "443"
+            - Name: datahub.admin.api.es.scheme
+              Value: "https"
+            - Name: JAVA_OPTS
+              Value: "-Xmx512M -Xms512M"
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref AWS::Region
+              awslogs-group: !Ref AdminAPILogGroupProd
+              awslogs-stream-prefix: ecs
+
+  AdminAPILogGroupProd:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: "/ecs/admin-api-prod-taskdef"

--- a/update-stack.sh
+++ b/update-stack.sh
@@ -1,2 +1,4 @@
 #!/bin/sh
-aws cloudformation update-stack --stack-name datahub-lambda-codebuild-ecr --template-body file://codebuild.template.yml
+aws cloudformation deploy --stack-name datahub-lambda-codebuild-ecr --template-file codebuild-lambdas.template.yaml
+aws cloudformation deploy --stack-name datahub-ecs-codebuild-ecr --template-file codebuild-ecs.template.yaml
+aws cloudformation deploy --stack-name datahub-ecs-services --template-file ecs.template.yaml


### PR DESCRIPTION
### Changes
- Removed create-stack.sh script (deprecated)
- Changed update-stack.sh to use deploy command so stacks can be created/updated idempotently
- Added ecs services cfn template for admin ui and admin api
- Added codebuild projects cfn template for admin ui and admin api