### PR TITLE
Start dev admin ui and api

### DIFF
--- a/codebuild-ecs.template.yaml
+++ b/codebuild-ecs.template.yaml
@@ -88,7 +88,7 @@ Resources:
             Value: !Ref ClusterNameDev # TODO replace this with import
             Type: PLAINTEXT
           - Name: ECS_SERVICE
-            Value: "admin-ui-dev" # TODO replace this with import
+            Value: "admin-ui-service-dev" # TODO replace this with import
             Type: PLAINTEXT
       Name: admin-ui-dev
       ServiceRole: "{{resolve:ssm:codebuild-role-arn:1}}"
@@ -128,7 +128,7 @@ Resources:
             Value: !Ref ClusterNameStage # TODO replace this with import
             Type: PLAINTEXT
           - Name: ECS_SERVICE
-            Value: "admin-ui-stage" # TODO replace this with import
+            Value: "admin-ui-service-stage" # TODO replace this with import
             Type: PLAINTEXT
       Name: admin-ui-stage
       ServiceRole: "{{resolve:ssm:codebuild-role-arn:1}}"
@@ -171,7 +171,7 @@ Resources:
             Value: !Ref ClusterNameProd
             Type: PLAINTEXT
           - Name: SERVICE_NAME
-            Value: "admin-ui-prod-service" # TODO replace with import
+            Value: "admin-ui-service-prod" # TODO replace with import
             Type: PLAINTEXT
       Name: admin-ui-prod-promotion
       ServiceRole: "{{resolve:ssm:codebuild-role-arn:1}}"

--- a/codebuild-ecs.template.yaml
+++ b/codebuild-ecs.template.yaml
@@ -190,3 +190,180 @@ Resources:
                 - docker tag $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/$STAGE_REPO_NAME:latest $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/$PROD_REPO_NAME:latest
                 - docker push $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/$PROD_REPO_NAME:latest
                 - aws ecs update-service --cluster $CLUSTER_NAME --service $SERVICE_NAME --force-new-deployment
+
+ ######################
+  ### Admin API Resources
+
+  # ECR Repositories
+  AdminAPIDev:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: admin-api-dev
+  AdminAPIStage:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: admin-api-stage
+  AdminAPIProd:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: admin-api-prod
+
+  # CodeBuild Projects
+  AdminAPICodeBuildGeneric:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Description: CodeBuild project for testing buildability of all commits.
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/standard:3.0
+        Type: LINUX_CONTAINER
+        PrivilegedMode: True
+        EnvironmentVariables:
+          - Name: AWS_ACCOUNT_ID
+            Type: PLAINTEXT
+            Value: "null"
+          - Name: IMAGE_REPO_NAME
+            Type: PLAINTEXT
+            Value: "null"
+      Name: admin-api-generic
+      ServiceRole: "{{resolve:ssm:codebuild-role-arn:1}}"
+      Source:
+        Auth:
+          Type: OAUTH
+        Location: https://github.com/usdot-its-jpo-data-portal/datahub-admin-api.git
+        Type: GITHUB
+      Triggers:
+        FilterGroups:
+          - - Type: EVENT
+              Pattern: PUSH
+            - Type: HEAD_REF
+              Pattern: "^refs/heads/(master|development)$"
+              ExcludeMatchedPattern: True
+        Webhook: True
+
+  AdminAPICodeBuildDev:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Description: CodeBuild project for deploying the Admin API service to dev.
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/standard:3.0
+        Type: LINUX_CONTAINER
+        PrivilegedMode: True
+        EnvironmentVariables:
+          - Name: AWS_ACCOUNT_ID
+            Value: !Ref AWS::AccountId
+            Type: PLAINTEXT
+          - Name: IMAGE_REPO_NAME
+            Value: !Ref AdminAPIDev
+            Type: PLAINTEXT
+          - Name: ECS_CLUSTER
+            Value: !Ref ClusterNameDev # TODO replace this with import
+            Type: PLAINTEXT
+          - Name: ECS_SERVICE
+            Value: "admin-api-service-dev" # TODO replace this with import
+            Type: PLAINTEXT
+      Name: admin-api-dev
+      ServiceRole: "{{resolve:ssm:codebuild-role-arn:1}}"
+      Source:
+        Auth:
+          Type: OAUTH
+        Location: https://github.com/usdot-its-jpo-data-portal/datahub-admin-api.git
+        Type: GITHUB
+      Triggers:
+        FilterGroups:
+          - - Type: EVENT
+              Pattern: PUSH
+            - Type: HEAD_REF
+              Pattern: "^refs/heads/development$"
+              ExcludeMatchedPattern: False
+        Webhook: True
+
+  AdminAPICodeBuildStage:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Description: CodeBuild project for deploying the Admin API service to stage.
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/standard:3.0
+        Type: LINUX_CONTAINER
+        PrivilegedMode: True
+        EnvironmentVariables:
+          - Name: AWS_ACCOUNT_ID
+            Value: !Ref AWS::AccountId
+            Type: PLAINTEXT
+          - Name: IMAGE_REPO_NAME
+            Value: !Ref AdminAPIStage
+            Type: PLAINTEXT
+          - Name: ECS_CLUSTER
+            Value: !Ref ClusterNameStage # TODO replace this with import
+            Type: PLAINTEXT
+          - Name: ECS_SERVICE
+            Value: "admin-api-service-stage" # TODO replace this with import
+            Type: PLAINTEXT
+      Name: admin-api-stage
+      ServiceRole: "{{resolve:ssm:codebuild-role-arn:1}}"
+      Source:
+        Auth:
+          Type: OAUTH
+        Location: https://github.com/usdot-its-jpo-data-portal/datahub-admin-api.git
+        Type: GITHUB
+      Triggers:
+        FilterGroups:
+          - - Type: EVENT
+              Pattern: PUSH
+            - Type: HEAD_REF
+              Pattern: "^refs/heads/master$"
+              ExcludeMatchedPattern: False
+        Webhook: True
+
+  AdminAPICodeBuildProd:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Description: CodeBuild project for promoting the Admin API service from stage to prod.
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/standard:3.0
+        Type: LINUX_CONTAINER
+        PrivilegedMode: True
+        EnvironmentVariables:
+          - Name: STAGE_REPO_NAME
+            Value: !Ref AdminAPIStage
+            Type: PLAINTEXT
+          - Name: PROD_REPO_NAME
+            Value: !Ref AdminAPIProd
+            Type: PLAINTEXT
+          - Name: AWS_ACCOUNT_ID
+            Value: !Ref AWS::AccountId
+            Type: PLAINTEXT
+          - Name: $CLUSTER_NAME
+            Value: !Ref ClusterNameProd
+            Type: PLAINTEXT
+          - Name: SERVICE_NAME
+            Value: "admin-api-service-prod" # TODO replace with import
+            Type: PLAINTEXT
+      Name: admin-api-prod-promotion
+      ServiceRole: "{{resolve:ssm:codebuild-role-arn:1}}"
+      Source:
+        Type: NO_SOURCE
+        BuildSpec: |
+          version: 0.2
+          phases:
+            install:
+              runtime-versions:
+                docker: 18
+            build:
+              commands:
+                - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+                - docker pull $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/$STAGE_REPO_NAME:latest
+                - docker tag $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/$STAGE_REPO_NAME:latest $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/$PROD_REPO_NAME:latest
+                - docker push $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/$PROD_REPO_NAME:latest
+                - aws ecs update-service --cluster $CLUSTER_NAME --service $SERVICE_NAME --force-new-deployment

--- a/ecs.template.yaml
+++ b/ecs.template.yaml
@@ -42,7 +42,7 @@ Resources:
       DeploymentConfiguration:
         MinimumHealthyPercent: 100
         MaximumPercent: 200
-      DesiredCount: 0 # TODO replace with 1 when codebuild deployments are successful
+      DesiredCount: 1
       HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
       NetworkConfiguration:
@@ -327,7 +327,7 @@ Resources:
       DeploymentConfiguration:
         MinimumHealthyPercent: 100
         MaximumPercent: 200
-      DesiredCount: 0 # TODO replace with 1 when codebuild deployments are successful
+      DesiredCount: 1
       HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
       NetworkConfiguration:


### PR DESCRIPTION
The desiredcount was set to zero for these services since the code wasn't compiled into aws yet.

Now that the admin-ui and admin-api code has been merged into development, this change will initialize the services.

Note - these were set to zero to prevent fargate from attempting to pull from an ECR repo that was empty.