### PR TITLE
Add no-fail flag to prevent false errors

### DIFF
--- a/update-stack.sh
+++ b/update-stack.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-aws cloudformation deploy --stack-name datahub-lambda-codebuild-ecr --template-file codebuild-lambdas.template.yaml
-aws cloudformation deploy --stack-name datahub-ecs-codebuild-ecr --template-file codebuild-ecs.template.yaml
-aws cloudformation deploy --stack-name datahub-ecs-services --template-file ecs.template.yaml
-aws cloudformation deploy --stack-name datahub-sqs --template-file sqs.template.yaml
+aws cloudformation deploy --no-fail-on-empty-changeset --stack-name datahub-lambda-codebuild-ecr --template-file codebuild-lambdas.template.yaml
+aws cloudformation deploy --no-fail-on-empty-changeset --stack-name datahub-ecs-codebuild-ecr --template-file codebuild-ecs.template.yaml
+aws cloudformation deploy --no-fail-on-empty-changeset --stack-name datahub-ecs-services --template-file ecs.template.yaml
+aws cloudformation deploy --no-fail-on-empty-changeset --stack-name datahub-sqs --template-file sqs.template.yaml


### PR DESCRIPTION
Cloudformation considers it an error to deploy a CloudFormation stack when there are no changes. This flag allows the command to still exit 0. 